### PR TITLE
错误码接受字符串而不只是整型数值

### DIFF
--- a/src/Lib/ResponseContent/StandardResponseContent.php
+++ b/src/Lib/ResponseContent/StandardResponseContent.php
@@ -8,7 +8,7 @@ use Hrb981027\TreasureBag\Lib\Enum\ResponseCode;
 
 class StandardResponseContent
 {
-    private int $code;
+    private int|string $code;
 
     private string $message;
 
@@ -26,7 +26,7 @@ class StandardResponseContent
         return $this->code;
     }
 
-    public function setCode(int $code): self
+    public function setCode(int|string $code): self
     {
         $this->code = $code;
 


### PR DESCRIPTION
数据库类型报错错误码一般是字符串形式